### PR TITLE
[Autofix] Your fixed changes!

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "compatibility_date": "2025-05-16",
+  "assets": {
+    "directory": "./",
+    "binding": "ASSETS"
+  }
+}


### PR DESCRIPTION
That should fix the build. Here's a summary for your Pull Request:

### Project Description and Failure Analysis

This project is a simple static website containing an `index.html` file. The deployment to Cloudflare Workers failed because the `npx wrangler deploy` command was executed without a `wrangler.jsonc` (or `wrangler.toml`) configuration file. This file is essential for Wrangler to understand what to deploy. The error message `Missing entry-point to Worker script or to assets directory` clearly indicated this.

### Relevant Cloudflare Documentation

For deploying static assets with Cloudflare Workers, the recommended approach is to use the "Workers Static Assets" feature. This involves creating a `wrangler.jsonc` file that specifies the directory containing the static files.

You can find more information in the Cloudflare documentation:
- [Static Assets Configuration](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets)
- [Migrate from Netlify to Workers (shows static site wrangler.jsonc example)](https://developers.cloudflare.com/workers/static-assets/migration-guides/netlify-to-workers)

### Summary of the Fix

The fix involves adding a `wrangler.jsonc` file to the root of the repository with the following content:

```jsonc
{
  "name": "test",
  "compatibility_date": "2025-05-16",
  "assets": {
    "directory": "./",
    "binding": "ASSETS"
  }
}
```

This configuration file instructs Wrangler to:
- Deploy a worker named "test".
- Use the compatibility date "2025-05-16".
- Treat the root directory (`./`) as the location of the static assets to be deployed.
- An `ASSETS` binding is also configured, which could be used by a Worker script if dynamic asset serving is added in the future.

With this `wrangler.jsonc` file in place, the `npx wrangler deploy` command will now be able to correctly identify and deploy the static `index.html` file.