### PR TITLE
[Autofix] Your fixed changes!

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "compatibility_date": "2025-05-16",
+  "assets": {
+    "directory": "./"
+  }
+}


### PR DESCRIPTION
Okay, the `wrangler.jsonc` file has been created.

Here's a summary of the changes and why they were needed:

## Project Description and Failure Analysis

The project "test" appears to be a simple static website, as indicated by the presence of an `index.html` file in the root directory. The build failed because the `npx wrangler deploy` command was executed without any configuration specifying what to deploy. Wrangler needs to be told whether it's deploying a Worker script or a directory of static assets. In this case, it's the latter.

## Relevant Documentation

For deploying static assets with Cloudflare Workers, the `wrangler.jsonc` (or `wrangler.toml`) configuration file is used. This file tells Wrangler where to find the static files.

You can find more information in the Cloudflare documentation:
*   **Static Assets Configuration:** [https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets)
*   **Get Started with Static Assets:** [https://developers.cloudflare.com/workers/static-assets/get-started](https://developers.cloudflare.com/workers/static-assets/get-started)

## Summary of the Fix

To resolve the build failure, I've added a `wrangler.jsonc` file to the root of the repository with the following content:

```jsonc
{
  "name": "test",
  "compatibility_date": "2025-05-16",
  "assets": {
    "directory": "./"
  }
}
```

This configuration tells Wrangler:
*   The name of the worker is "test".
*   To use a compatibility date of "2025-05-16".
*   That this is a static asset deployment, and the assets are located in the root directory (`./`).

With this `wrangler.jsonc` file in place, the `npx wrangler deploy` command will now correctly identify and deploy the `index.html` file and any other static assets in the repository.