### PR TITLE
[Autofix] Your fixed changes!

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "compatibility_date": "2025-05-24",
+  "assets": {
+    "directory": "./"
+  }
+}


### PR DESCRIPTION
That should resolve the build failure.

## Pull Request Summary

### Project Description and Failure Analysis

This project is a static website, identified by the presence of an `index.html` file at the root of the repository. The build failed because the `npx wrangler deploy` command was executed without a configuration file or command-line arguments specifying what to deploy. The build logs show the error `✘ [ERROR] Missing entry-point to Worker script or to assets directory`, indicating Wrangler could not find a Worker script or a directory of static assets.

### Relevant Documentation

For deploying static assets with Cloudflare Workers using Wrangler, a `wrangler.json` (or `wrangler.toml`) configuration file is used. The key configuration is the `assets` property, which specifies the directory containing the static files.

*   **Wrangler Configuration:** [https://developers.cloudflare.com/workers/wrangler/configuration/](https://developers.cloudflare.com/workers/wrangler/configuration/)
*   **Static Assets with Workers:** [https://developers.cloudflare.com/workers/static-assets/](https://developers.cloudflare.com/workers/static-assets/)

These documents explain how to structure the `wrangler.json` file, including the `name`, `compatibility_date`, and `assets` fields.

### Summary of the Fix

The deployment was fixed by adding a `wrangler.json` file to the root of the repository with the following content:

```json
{
  "name": "test",
  "compatibility_date": "2025-05-24",
  "assets": {
    "directory": "./"
  }
}
```

This configuration informs Wrangler:
*   The name of the Worker is "test".
*   To use a compatibility date of "2025-05-24".
*   To deploy the files located in the current directory (`./`) as static assets.

This change provides Wrangler with the necessary information to deploy the `index.html` file as a static site.