### PR TITLE
[Autofix] Your fixed changes!

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "compatibility_date": "2025-05-16",
+  "assets": {
+    "directory": "."
+  }
+}


### PR DESCRIPTION
Okay, I've created the `wrangler.jsonc` file.

Here's a summary of the changes:

### Project Description and Failure Analysis

The project "test" appears to be a simple static website, containing an `index.html` file at its root. The deployment failed because the Wrangler CLI, used in the `deploy_command: "npx wrangler deploy"`, was not configured to know where the static assets of the website were located. The build logs clearly state: `✘ [ERROR] Missing entry-point to Worker script or to assets directory`.

### Relevant Documentation

For deploying static assets with Cloudflare Workers, the `wrangler.jsonc` (or `wrangler.toml`) configuration file is used to specify the directory containing the static files.

- **Static Assets Configuration**: You can configure static assets by adding an `assets` object to your `wrangler.jsonc`. The `directory` key within this object specifies the path to your static files.
  - More information can be found in the [Cloudflare Workers static assets documentation](https://developers.cloudflare.com/workers/static-assets/get-started) and specifically for [Workers for Platforms](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/configuration/static-assets).

### Summary of the Fix

To resolve the build failure, I've added a `wrangler.jsonc` file to the root of the repository with the following content:

```jsonc
{
  "name": "test",
  "compatibility_date": "2025-05-16",
  "assets": {
    "directory": "."
  }
}
```

This configuration file informs Wrangler:
- The name of the worker is "test".
- The compatibility date to use for the Worker's runtime.
- The `assets.directory` is set to `"."`, indicating that the static files (like `index.html`) are located in the root directory of the project.

With this `wrangler.jsonc` file in place, the `npx wrangler deploy` command will now correctly identify and deploy the static assets of the "test" project.