### PR TITLE
[Autofix] Your fixed changes!

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "compatibility_date": "2025-05-16",
+  "assets": {
+    "directory": "./"
+  }
+}


### PR DESCRIPTION
The `wrangler.jsonc` file has been created. This should resolve the build failure. When the build runs again, Wrangler will now correctly identify the project as a static site and deploy the contents of the root directory.