### PR TITLE
[Autofix] Your fixed changes!

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -1,0 +1,7 @@
+{
+  "name": "test",
+  "compatibility_date": "2025-05-16",
+  "assets": {
+    "directory": "./"
+  }
+}


### PR DESCRIPTION
## Project Description and Failure Analysis

The project appears to be a simple static website, as indicated by the presence of an `index.html` file and the absence of any server-side code or complex framework-specific configuration.

The deployment failed because the `npx wrangler deploy` command, as configured in the build process, could not find an entry point for a Worker script or a directory of static assets to deploy. The build logs clearly state: `✘ [ERROR] Missing entry-point to Worker script or to assets directory`. Wrangler needs to be told what to deploy.

## Relevant Documentation

For deploying a static site with Cloudflare Workers, the primary method involves configuring Wrangler to recognize a directory of assets. The `wrangler.json` (or `wrangler.toml`) configuration file is used for this.

According to the Cloudflare documentation on [Static Assets Configuration and Bindings](https://developers.cloudflare.com/workers/static-assets/binding) and [migrating from Netlify to Workers (which shows static site configuration)](https://developers.cloudflare.com/workers/static-assets/migration-guides/netlify-to-workers), you need to specify an `assets` object in your `wrangler.json` file. This object should contain a `directory` key pointing to the folder containing your static files.

While "Workers Sites" was a previous way to handle this, the documentation now recommends using "Workers Static Assets":
> You should use [Workers Static Assets](/workers/static-assets/) to host full-stack applications instead of Workers Sites. It has been deprecated in Wrangler v4... Do not use Workers Sites for new projects.

## Summary of the Fix

To resolve the build failure, I have added a `wrangler.json` file to the root of the repository with the following content:

```json
{
  "name": "test",
  "compatibility_date": "2025-05-16",
  "assets": {
    "directory": "./"
  }
}
```

This configuration tells Wrangler:
- The name of the worker is "test" (inferred from the repository name).
- The compatibility date to use for the Worker.
- That this project includes static assets located in the root directory (`./`).

With this `wrangler.json` file in place, the `npx wrangler deploy` command will now correctly identify the `index.html` file (and any other assets in the root) and deploy them as a static site.